### PR TITLE
Use the legacy generator

### DIFF
--- a/examples/2D/anisotropic/2Dddc.i
+++ b/examples/2D/anisotropic/2Dddc.i
@@ -34,6 +34,7 @@
     variable = noise
     max = 0.003
     min = -0.003
+    legacy_generator = true
   [../]
   [./pressure]
     type = ConstantIC

--- a/examples/2D/isotropic/2Dddc.i
+++ b/examples/2D/isotropic/2Dddc.i
@@ -34,6 +34,7 @@
     variable = noise
     max = 0.003
     min = -0.003
+    legacy_generator = true
   [../]
   [./pressure]
     type = ConstantIC

--- a/examples/3D/isotropic/3Dddc.i
+++ b/examples/3D/isotropic/3Dddc.i
@@ -33,6 +33,7 @@
     variable = noise
     max = 0.003
     min = -0.003
+    legacy_generator = true
   [../]
   [./pressure]
     type = ConstantIC

--- a/examples/inputfiles/2D.i
+++ b/examples/inputfiles/2D.i
@@ -35,6 +35,7 @@
     variable = noise
     max = 0.003
     min = -0.003
+    legacy_generator = true
   [../]
 []
 

--- a/examples/inputfiles/3D.i
+++ b/examples/inputfiles/3D.i
@@ -36,6 +36,7 @@
     variable = noise
     max = 0.003
     min = -0.003
+    legacy_generator = true
   [../]
 []
 

--- a/tests/1D/1D_error.i
+++ b/tests/1D/1D_error.i
@@ -73,12 +73,14 @@
     min = 0
     max = 1
     variable = concentration
+    legacy_generator = true
   [../]
   [./pressureIC]
     type = RandomIC
     min = 1e6
     max = 2e6
     variable = pressure
+    legacy_generator = true
   [../]
 []
 

--- a/tests/bcs/perturbation.i
+++ b/tests/bcs/perturbation.i
@@ -25,6 +25,7 @@
     variable = noise
     min = 0
     max = 0.05
+    legacy_generator = true
   [../]
 []
 

--- a/tests/bcs/perturbation_adaptivity.i
+++ b/tests/bcs/perturbation_adaptivity.i
@@ -37,6 +37,7 @@
     variable = noise
     min = 0
     max = 0.05
+    legacy_generator = true
   [../]
 []
 

--- a/tests/jacobians/2D.i
+++ b/tests/jacobians/2D.i
@@ -73,12 +73,14 @@
     min = 0
     max = 1
     variable = concentration
+    legacy_generator = true
   [../]
   [./pressureIC]
     type = RandomIC
     min = 1e6
     max = 2e6
     variable = pressure
+    legacy_generator = true
   [../]
 []
 

--- a/tests/jacobians/2DDG.i
+++ b/tests/jacobians/2DDG.i
@@ -78,12 +78,14 @@
     min = 0
     max = 1
     variable = concentration
+    legacy_generator = true
   [../]
   [./pressureIC]
     type = RandomIC
     min = 1e6
     max = 2e6
     variable = pressure
+    legacy_generator = true
   [../]
 []
 

--- a/tests/jacobians/2DSF.i
+++ b/tests/jacobians/2DSF.i
@@ -48,12 +48,14 @@
     min = 0
     max = 1
     variable = concentration
+    legacy_generator = true
   [../]
   [./streamfunctionIC]
     type = RandomIC
     min = -1
     max = 1
     variable = streamfunction
+    legacy_generator = true
   [../]
 []
 

--- a/tests/jacobians/2DSFAnisotropic.i
+++ b/tests/jacobians/2DSFAnisotropic.i
@@ -50,12 +50,14 @@
     min = 0
     max = 1
     variable = concentration
+    legacy_generator = true
   [../]
   [./streamfunctionIC]
     type = RandomIC
     min = -1
     max = 1
     variable = streamfunction
+    legacy_generator = true
   [../]
 []
 

--- a/tests/jacobians/3D.i
+++ b/tests/jacobians/3D.i
@@ -74,12 +74,14 @@
     min = 0
     max = 1
     variable = concentration
+    legacy_generator = true
   [../]
   [./pressureIC]
     type = RandomIC
     min = 1e6
     max = 2e6
     variable = pressure
+    legacy_generator = true
   [../]
 []
 

--- a/tests/jacobians/3DSF.i
+++ b/tests/jacobians/3DSF.i
@@ -101,17 +101,20 @@
     min = 0
     max = 1
     variable = concentration
+    legacy_generator = true
   [../]
   [./streamfunctionxIC]
     type = RandomIC
     min = -1
     max = 1
     variable = streamfunctionx
+    legacy_generator = true
   [../]
   [./streamfunctionyIC]
     type = RandomIC
     min = -1
     max = 1
     variable = streamfunctiony
+    legacy_generator = true
   [../]
 []

--- a/tests/jacobians/3DSFAnisotropic.i
+++ b/tests/jacobians/3DSFAnisotropic.i
@@ -104,17 +104,20 @@
     min = 0
     max = 1
     variable = concentration
+    legacy_generator = true
   [../]
   [./streamfunctionxIC]
     type = RandomIC
     min = -1
     max = 1
     variable = streamfunctionx
+    legacy_generator = true
   [../]
   [./streamfunctionyIC]
     type = RandomIC
     min = -1
     max = 1
     variable = streamfunctiony
+    legacy_generator = true
   [../]
 []

--- a/tests/materials/porosity_fluctuation.i
+++ b/tests/materials/porosity_fluctuation.i
@@ -30,6 +30,7 @@
     variable = porosity_noise
     max = 0.02
     min = -0.02
+    legacy_generator = true
   [../]
 []
 

--- a/tests/materials/porosity_fluctuation_fromvar.i
+++ b/tests/materials/porosity_fluctuation_fromvar.i
@@ -39,6 +39,7 @@
     variable = porosity_noise
     max = 0.025
     min = -0.025
+    legacy_generator = true
   [../]
 []
 


### PR DESCRIPTION
MOOSE now defaults to using a new parallel consistent generator for RandomIC. Each of these tests should be re-evaluated and re-golded as necessary after removing this "legacy" parameter. The legacy parameter will allow you to run unchanged until you have time to look into the changes.