### PR TITLE
Do not use legacy dirichlet BC

### DIFF
--- a/src/base/NumbatApp.C
+++ b/src/base/NumbatApp.C
@@ -18,6 +18,7 @@ InputParameters
 validParams<NumbatApp>()
 {
   InputParameters params = validParams<MooseApp>();
+  params.set<bool>("use_legacy_dirichlet_bc") = false;
   return params;
 }
 


### PR DESCRIPTION
@cpgr one more.

Right now, the default is to _not_ preset DirichletBCs. I pushed changes to numbat assuming this was not the case, and that the default was to preset DirichletBCs. Whoops!

Once the default is changed, I will remove this parameter set.