### PR TITLE
Remove unused params

### DIFF
--- a/examples/3D/barriers/3DddcSF.i
+++ b/examples/3D/barriers/3DddcSF.i
@@ -7,7 +7,6 @@
 
 [Mesh]
   type = FileMesh
-  file = barrier.msh
 []
 
 [Numbat]

--- a/examples/3D/isotropic/3DddcSF_Ra5000.i
+++ b/examples/3D/isotropic/3DddcSF_Ra5000.i
@@ -9,7 +9,6 @@
 
 [Mesh]
   type = FileMesh
-  file = Ra5000.e
 []
 
 [Numbat]

--- a/tests/effective_permeability/2D_barrier.i
+++ b/tests/effective_permeability/2D_barrier.i
@@ -23,7 +23,6 @@
     type = BlockDeletionGenerator
     input = barrier
     block_id = 1
-    depends_on = barrier
   [../]
 []
 


### PR DESCRIPTION
MOOSE is changing the default behavior of unused parameters from a warning to an error. Since there are tests in this Moose app with unused parameters, this app's tests must have there unused parameters removed.

I am particularly concerned about some of these parameters making the tests not work as intended once removed, as two of the changes are removing specifications for mesh files(?!) so please review just to make sure.

Closes #15 