### PR TITLE
Remove unnecessary bcs block in 1D error test

### DIFF
--- a/tests/1D/1D_error.i
+++ b/tests/1D/1D_error.i
@@ -58,15 +58,6 @@
   [../]
 []
 
-[BCs]
-  [./conctop]
-    type = DirichletBC
-    variable = concentration
-    boundary = top
-    value = 1.0
-  [../]
-[]
-
 [ICs]
   [./concentrationIC]
     type = RandomIC


### PR DESCRIPTION
In idaholab/moose#21108 the topological sorting of tasks changes
and boundary condition addition now happens before kernel addition.
In order to get the expected error in this test, we need to remove
the boundary conditions block (which has its own, different error)